### PR TITLE
Include Mapbox as supported maps provider of moko-maps

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -219,7 +219,7 @@ necessary. For example, to implement a native UI or when working with platform-s
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dev.icerock.moko/media/badge.svg)](https://maven-badges.herokuapp.com/maven-central/dev.icerock.moko/media)
 > This is a Kotlin Multiplatform library that provides media picking in common code (photo/video) and video player controls.
 
-[MOKO Maps](https://github.com/icerockdev/moko-maps) - Google maps manager
+[MOKO Maps](https://github.com/icerockdev/moko-maps) - Google/Mapbox maps manager
 [![GitHub Repo stars](https://img.shields.io/github/stars/icerockdev/moko-maps)](https://github.com/icerockdev/moko-maps)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dev.icerock.moko/maps/badge.svg)](https://maven-badges.herokuapp.com/maven-central/dev.icerock.moko/maps)
 > This is a Kotlin Multiplatform library that provides controls of maps to common code.


### PR DESCRIPTION
The [moko-maps](https://github.com/icerockdev/moko-maps) module supports, next to Google, Mapbox as a map provider. 
This PR updates the `README.md` to communicate that to readers. 