### PR TITLE
Add PdfKmp library

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1247,6 +1247,11 @@ your Compose apps.
 [![Maven Central](https://img.shields.io/maven-central/v/com.eygraber/jsonpathkt-kotlinx)](https://central.sonatype.com/artifact/com.eygraber/jsonpathkt-kotlinx)
 > JsonPathKt provides a fast and performant way to work with JsonPath in Kotlin Multiplatform projects.
 
+[PdfKmp](https://github.com/ConaMobileDev/PdfKmp) - Kotlin Multiplatform PDF generator
+[![GitHub Repo stars](https://img.shields.io/github/stars/ConaMobileDev/PdfKmp?style=flat)](https://github.com/ConaMobileDev/PdfKmp)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.conamobiledev/pdfkmp)](https://central.sonatype.com/artifact/io.github.conamobiledev/pdfkmp)
+A Kotlin Multiplatform PDF generator for Android and iOS. Vector text and shapes authored with a Compose-style DSL — no rasterisation, so output stays sharp at any zoom.
+
 ## Contribution guide
 Feel free to contribute. Follow common style and welcome!  
 Few rules:  


### PR DESCRIPTION
Adds [PdfKmp](https://github.com/ConaMobileDev/PdfKmp), an open-source Kotlin Multiplatform library for PDF generation with a Compose-style declarative DSL.

- Pure Kotlin Multiplatform (Android, iOS)
- Declarative DSL for building PDF documents, similar to Compose
- Lightweight, no platform-specific PDF engine dependencies in the public API

Repo: https://github.com/ConaMobileDev/PdfKmp