### PR TITLE
Add Ghost Serializer to Serializer section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -680,6 +680,11 @@ Bluetooth in general has the same functionality for all platforms, e.g. connect 
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-serialization-core)](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-core)
 > Kotlin serialization consists of a compiler plugin, that generates visitor code for serializable classes, runtime library with core serialization API and support libraries with various serialization formats.
 
+[Ghost Serializer](https://github.com/juanchurtado1991/ghost-serializer) - High-performance compile-time JSON serializer
+[![GitHub Repo stars](https://img.shields.io/github/stars/juanchurtado1991/ghost-serializer?style=flat)](https://github.com/juanchurtado1991/ghost-serializer)
+[![Maven Central](https://img.shields.io/maven-central/v/com.ghostserializer/ghost-serialization)](https://central.sonatype.com/artifact/com.ghostserializer/ghost-serialization)
+> Byte-first JSON serializer for KMP (Android, iOS, JVM) with KSP compile-time codegen, thread-local pools, and coexistence with kotlinx.serialization, Gson, and Jackson. Integrations for Ktor, Retrofit, and Spring Boot. Optional ghost-protobuf module for proto3 JSON mapping.
+
 [Ksoup (fleeksoft)](https://github.com/fleeksoft/ksoup) - HTML & XML Parser (Jsoup Alternative)
 [![GitHub Repo stars](https://img.shields.io/github/stars/fleeksoft/ksoup?style=flat)](https://github.com/fleeksoft/ksoup)
 [![Maven Central](https://img.shields.io/maven-central/v/com.fleeksoft.ksoup/ksoup)](https://central.sonatype.com/artifact/com.fleeksoft.ksoup/ksoup)


### PR DESCRIPTION
## Summary

Adds [Ghost Serializer](https://github.com/juanchurtado1991/ghost-serializer) to the **🗃 Serializer** section, after `kotlinx.serialization`.

Ghost is a compile-time JSON serializer for Kotlin Multiplatform (Android, iOS, JVM) powered by KSP. It targets high-traffic REST paths with byte-first parsing, thread-local pools, and integrations for Ktor, Retrofit, and Spring Boot. It coexists with kotlinx.serialization, Gson, and Jackson — only `@GhostSerialization` models use Ghost; the rest fall through to the existing stack.

Published on Maven Central as `com.ghostserializer:ghost-serialization` (v1.2.7).

The optional `ghost-protobuf` module (proto3 JSON mapping) is mentioned in the description but not listed as a separate entry, since it is part of the same project and is not a binary protobuf implementation like Pbandk.

## Checklist

- [x] Entry follows the existing README format (link, GitHub stars badge, Maven Central badge, description)
- [x] Placed in the Serializer section alongside related libraries
- [x] Library supports iOS and Android targets (KMP)